### PR TITLE
Adds graceful shutdown for proxy server and task queue

### DIFF
--- a/gateway/common/config.go
+++ b/gateway/common/config.go
@@ -1,0 +1,10 @@
+package common
+
+import (
+    "time"
+)
+
+// store config as constants for now
+const (
+    SHUTDOWN_DELAY = 5 * time.Second
+)

--- a/gateway/common/tasks.go
+++ b/gateway/common/tasks.go
@@ -71,8 +71,8 @@ func (q *TaskQueue) CloseQueue() {
             if len(q.Tasks) == 0 {
                 return
             }
-        case <-time.After(5 * time.Second):
-            log.Println("workers not finished after 5 seconds, lost")
+        case <-time.After(SHUTDOWN_DELAY):
+            log.Println("workers not finished, work may be lost")
             return
         }
     }

--- a/gateway/common/tasks.go
+++ b/gateway/common/tasks.go
@@ -5,6 +5,7 @@ import (
     "os"
     "strconv"
     "sync"
+    "time"
 )
 
 // TODO make it "pluggable" so different types of tasks can operate off queue
@@ -62,6 +63,19 @@ func (q *TaskQueue) SetupWorkers() {
 // use this for graceful shutdown
 func (q *TaskQueue) CloseQueue() {
     close(q.Tasks)
+
+    ticker := time.NewTicker(100 * time.Millisecond)
+    for {
+        select {
+        case <-ticker.C:
+            if len(q.Tasks) == 0 {
+                return
+            }
+        case <-time.After(5 * time.Second):
+            log.Println("workers not finished after 5 seconds, lost")
+            return
+        }
+    }
 }
 
 func worker(q *TaskQueue) {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "log"
+    "os"
+    "os/signal"
+    "sync"
+    "syscall"
+
+    "porters/common"
+    "porters/proxy"
+)
+
+func gateway() {
+    // Start job queue
+    common.GetTaskQueue().SetupWorkers()
+
+    log.Println("starting gateway")
+    proxy.Start()
+
+    done := make(chan os.Signal)
+    signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+    <-done
+    shutdown()
+}
+
+func shutdown() {
+    var wg sync.WaitGroup
+
+    wg.Add(2)
+    go func() {
+        defer wg.Done()
+        proxy.Stop()
+    }()
+    go func() {
+        defer wg.Done()
+        common.GetTaskQueue().CloseQueue()
+    }()
+    wg.Wait()
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-    "log"
     "os"
 
-    "porters/common"
     "porters/plugins"
     "porters/proxy"
 )
@@ -16,16 +14,12 @@ func main() {
     arg := os.Args[1]
     if arg == "gateway" {
 
-        // Start job queue
-        common.GetTaskQueue().SetupWorkers()
-
         // currently registering plugins via main
         proxy.Register(&plugins.Counter{})
         proxy.Register(&plugins.ApiKeyAuth{"X-API"})
         proxy.Register(&plugins.BalanceTracker{})
         proxy.Register(&plugins.NoopFilter{proxy.LifecycleMask(proxy.AccountLookup|proxy.RateLimit)})
 
-        log.Println("starting gateway")
-        proxy.Start()
+        gateway()
     }
 }

--- a/gateway/proxy/proxy.go
+++ b/gateway/proxy/proxy.go
@@ -9,10 +9,10 @@ import (
     "net/http"
     "net/http/httputil"
     "os"
-    "time"
 
     "github.com/gorilla/mux"
 
+    "porters/common"
     "porters/db"
 )
 
@@ -60,7 +60,7 @@ func Start() {
 
 func Stop() {
     // 5 second shutdown
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    ctx, cancel := context.WithTimeout(context.Background(), common.SHUTDOWN_DELAY)
     defer cancel()
 
     err := server.Shutdown(ctx)

--- a/gateway/proxy/proxy.go
+++ b/gateway/proxy/proxy.go
@@ -9,11 +9,14 @@ import (
     "net/http"
     "net/http/httputil"
     "os"
+    "time"
 
     "github.com/gorilla/mux"
 
     "porters/db"
 )
+
+var server *http.Server
 
 func Start() {
     // TODO grab url for gateway kit
@@ -45,9 +48,26 @@ func Start() {
     router := mux.NewRouter()
     router.HandleFunc("/{appId}", handler(revProxy))
     router.HandleFunc("/health", healthHandler())
-    err2 := http.ListenAndServe(":9000", router)
-    if err2 != nil {
-        panic(err2)
+
+    server = &http.Server{Addr: ":9000", Handler: router}
+    go func() {
+        err := server.ListenAndServe()
+        if err != nil {
+            log.Println("server error", err)
+        }
+    }()
+}
+
+func Stop() {
+    // 5 second shutdown
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
+
+    err := server.Shutdown(ctx)
+    if err != nil {
+        log.Println("error shutting down", err)
+    } else {
+        log.Println("shutdown successful")
     }
 }
 


### PR DESCRIPTION
I pulled out the startup shutdown bits into a gateway.go to keep main.go simple. The idea is that someone might be able to depend on our package and implement their own main.go (or we could run multiple instances with different main.go setups). This waits 5 seconds at most on SIGINT or SIGTERM to clean up existing work. We might want to move other stuff to config, and include ENV reads as part of this pattern.