### PR TITLE
Tuning prod deploys

### DIFF
--- a/gateway/fly.prod.toml
+++ b/gateway/fly.prod.toml
@@ -22,7 +22,7 @@ primary_region = 'sea'
   internal_port = 9000
   force_https = true
   auto_stop_machines = false 
-  auto_start_machines = false
+  auto_start_machines = true
   processes = ['app']
   [[http_service.checks]]
     grace_period = '2s'

--- a/services/gatewaykit/fly.prod.toml
+++ b/services/gatewaykit/fly.prod.toml
@@ -25,7 +25,7 @@ primary_region = 'sea'
   internal_port = 8080
   protocol = 'tcp'
   auto_stop_machines = false
-  auto_start_machines = false
+  auto_start_machines = true
   [[services.ports]]
     handlers = ["http"]
     port = 8080
@@ -39,9 +39,9 @@ primary_region = 'sea'
     timeout = 1000
 
 [[vm]]
-  memory = '2gb'
+  memory = '4gb'
   cpu_kind = 'shared'
-  cpus = 1
+  cpus = 2
 
 [[metrics]]
   port = 8080


### PR DESCRIPTION
OOM on gatewaykit requires upping memory. Also enabling scale up (leaving scale down to a manual process). We will want to monitor so we aren't wasting cycles, but scale down currently removes machines from regions where we want to have at least one running in each region at all times.