### PR TITLE
Report rate limit events to prometheus gauge

### DIFF
--- a/gateway/common/prometheus.go
+++ b/gateway/common/prometheus.go
@@ -14,6 +14,7 @@ const (
     TENANT     = "tenant"
     QUEUE      = "queue"
     STAGE      = "stage"
+    RATE_LIMIT = "rateLimit"
 )
 
 var (
@@ -30,4 +31,8 @@ var (
         Help: "Shows how much the proxy process is adding to request",
         Buckets: prometheus.ExponentialBucketsRange(float64(10 * time.Millisecond), float64(20 * time.Second), 10),
     }, []string{STAGE})
+    RateLimitGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+        Name: "gateway_rate_limit_hit",
+        Help: "Shows rate limits hit on a gauge, resets to 0 when resolved",
+    }, []string{APP, TENANT, RATE_LIMIT})
 )

--- a/gateway/proxy/error.go
+++ b/gateway/proxy/error.go
@@ -3,7 +3,6 @@ package proxy
 import (
     "fmt"
     "net/http"
-    "time"
 )
 
 var FilterBlockError error = fmt.Errorf("filter chain stopped")
@@ -18,9 +17,9 @@ type HTTPError struct {
 func NewHTTPError(code int) *HTTPError {
     return &HTTPError{code}
 }
-func NewRateLimitError(limit int, period time.Duration) error {
-    return fmt.Errorf("rate limit of %d per %v exceeded: %w",
-        limit, period, NewHTTPError(http.StatusTooManyRequests))
+func NewRateLimitError(limit string) error {
+    return fmt.Errorf("rate limit of %s exceeded: %w",
+        limit, NewHTTPError(http.StatusTooManyRequests))
 }
 func (httpe *HTTPError) Error() string {
     return http.StatusText(httpe.code)


### PR DESCRIPTION
Adds rate limit hits to metrics. Clears gauge when success is achieved again.