### PR TITLE
Properly managing CORS headers

### DIFF
--- a/gateway/plugins/origin_test.go
+++ b/gateway/plugins/origin_test.go
@@ -1,0 +1,27 @@
+package plugins
+
+import (
+    "testing"
+)
+
+func TestAllowedOriginMatches(t *testing.T) {
+    want := true
+    origin := "http://test.com"
+    allowed := []string{"http://test2.com", "http://test.com"}
+    filter := &AllowedOriginFilter{}
+    got := filter.matchesRules(origin, allowed)
+    if want != got {
+        t.Fatal("origin doesn't match")
+    }
+}
+
+func TestAllowedOriginMismatch(t *testing.T) {
+    want := false
+    origin := "http://test3.com"
+    allowed := []string{"http://test2.com", "http://test.com"}
+    filter := &AllowedOriginFilter{}
+    got := filter.matchesRules(origin, allowed)
+    if want != got {
+        t.Fatal("origin doesn't match")
+    }
+}

--- a/gateway/proxy/proxy.go
+++ b/gateway/proxy/proxy.go
@@ -132,6 +132,7 @@ func setupProxy(remote *url.URL) *httputil.ReverseProxy {
 
     revProxy.ModifyResponse = func(resp *http.Response) error {
         ctx := resp.Request.Context()
+        defaultHeaders(resp)
 
         if common.Enabled(common.INSTRUMENT_ENABLED) {
             instr, ok := common.FromContext(ctx, common.INSTRUMENT)
@@ -189,6 +190,12 @@ func setupContext(req *http.Request) {
         ctx = common.UpdateContext(ctx, common.StartInstrument())
     }
     *req = *req.WithContext(ctx)
+}
+
+// Add or remove headers on response
+// Dealing with CORS mostly
+func defaultHeaders(resp *http.Response) {
+    resp.Header.Set("Access-Control-Allow-Origin", "*")
 }
 
 func lookupPoktId(req *http.Request) (string, bool) {


### PR DESCRIPTION
* Updated app rule to include origin headers if set

Not using regex for values anymore, should work better (requires exact match though w/ some exceptions)